### PR TITLE
Fix build error on node12 and above

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@akashic/akashic-engine": "~1.12.5",
     "@akashic/akashic-sandbox": "~0.13.3",
     "@types/lodash": "4.14.110",
-    "@types/node": "7.0.28",
+    "@types/node": "8.0.33",
     "jasmine": "~2.1.1",
     "rimraf": "^3.0.2",
     "tslint": "~5.9.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "noLib": true,
+    "lib": ["es5", "esnext.asynciterable"],
     "noImplicitAny": true,
     "suppressImplicitAnyIndexErrors": false,
     "removeComments": false,
@@ -10,8 +10,12 @@
     "outDir": "./game/script",
     "noUnusedLocals": true
   },
+  "files": [
+    "./node_modules/@akashic/akashic-engine/lib/main.d.ts",
+    "./node_modules/@akashic-extension/akashic-animation/lib/@akashic-extension/akashic-animation.d.ts",
+    "./node_modules/@akashic-extension/akashic-timeline/lib/index.d.ts"
+  ],
   "include": [
-    "./typings/**/*.ts",
     "./src/**/*.ts"
   ],
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,7 @@
     "noUnusedLocals": true
   },
   "files": [
-    "./node_modules/@akashic/akashic-engine/lib/main.d.ts",
-    "./node_modules/@akashic-extension/akashic-animation/lib/@akashic-extension/akashic-animation.d.ts",
-    "./node_modules/@akashic-extension/akashic-timeline/lib/index.d.ts"
+    "./node_modules/@akashic/akashic-engine/lib/main.d.ts"
   ],
   "include": [
     "./src/**/*.ts"

--- a/tsd.json
+++ b/tsd.json
@@ -1,8 +1,0 @@
-{
-  "version": "v4",
-  "repo": "borisyankov/DefinitelyTyped",
-  "ref": "master",
-  "path": "typings",
-  "bundle": "typings/tsd.d.ts",
-  "installed": {}
-}

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -1,5 +1,0 @@
-/// <reference path="../node_modules/typescript/lib/lib.es5.d.ts" />
-/// <reference path="../node_modules/typescript/lib/lib.dom.d.ts" />
-/// <reference path="../node_modules/@akashic/akashic-engine/lib/main.d.ts" />
-/// <reference path="../node_modules/@akashic-extension/akashic-animation/lib/@akashic-extension/akashic-animation.d.ts" />
-/// <reference path="../node_modules/@akashic-extension/akashic-timeline/lib/index.d.ts" />


### PR DESCRIPTION
## 概要

node12以上でビルド時に下記エラーが発生していた問題を修正
```
node_modules/@types/cors/index.d.ts(8,10): error TS2305: Module '"http"' has no exported member 'IncomingHttpHeaders'.
node_modules/@types/readable-stream/index.d.ts(104,17): error TS2339: Property 'asyncIterator' does not exist on type 'SymbolConstructor'.
node_modules/@types/readable-stream/index.d.ts(104,35): error TS2304: Cannot find name 'AsyncIterableIterator'.
```

node v12.22.1, v13.14.0, v14.17.0 で build/動作する事を確認
