### PR TITLE
fix: environment.nicolive instead of niconico

### DIFF
--- a/game/game.json
+++ b/game/game.json
@@ -989,7 +989,7 @@
 	},
 	"environment": {
 		"sandbox-runtime": "3",
-		"niconico": {
+		"nicolive": {
 			"supportedModes": [
 				"ranking"
 			]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-contents/thiefBuster",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "description": "Akashic Engine製ゲーム・泥棒バスター",
   "main": "index.js",


### PR DESCRIPTION
掲題の通りです。
[ニコ生ゲーム関連の仕様](https://akashic-games.github.io/guide/shin-ichiba/shin-ichiba-spec.html#supported-modes) の推奨に追従します。